### PR TITLE
Implementing State Locking Feature

### DIFF
--- a/dumie-cli/awsutils/aws_config.go
+++ b/dumie-cli/awsutils/aws_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
@@ -39,8 +40,8 @@ func LoadAWSConfig() (*AWSConfig, error) {
 	return &config, nil
 }
 
-// GetAWSClient initializes and returns an AWS EC2 client using the loaded configuration
-func GetAWSClient() (*ec2.Client, error) {
+// GetEC2AWSClient initializes and returns an AWS EC2 client using the loaded configuration
+func GetEC2AWSClient() (*ec2.Client, error) {
 	cfgData, err := LoadAWSConfig()
 	if err != nil {
 		return nil, err
@@ -60,6 +61,30 @@ func GetAWSClient() (*ec2.Client, error) {
 	}
 
 	client := ec2.NewFromConfig(awsCfg)
+	fmt.Println("Retrieved client:", client)
+	return client, nil
+}
+
+func GetDynamoDBClient() (*dynamodb.Client, error) {
+	cfgData, err := LoadAWSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(
+		context.TODO(),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			cfgData.AccessKeyID,
+			cfgData.SecretAccessKey,
+			"",
+		)),
+		config.WithRegion(cfgData.Region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
+	}
+
+	client := dynamodb.NewFromConfig(awsCfg)
 	fmt.Println("Retrieved client:", client)
 	return client, nil
 }

--- a/dumie-cli/awsutils/ddb_lock.go
+++ b/dumie-cli/awsutils/ddb_lock.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2025 Chanhyeok Seo chanhyeok.seo2@gmail.com
+*/
+package awsutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type DynamoDBLock struct {
+	Client    *dynamodb.Client
+	TableName string
+	TTL       time.Duration
+}
+
+const tableName = "dumie-lock-table"
+const ttl = 5 * time.Minute
+
+func SearchDynamoDBLockTable(client *dynamodb.Client) (bool, error) {
+	_, err := client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		if err.Error() == "ResourceNotFoundException" {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to describe table: %w", err)
+	}
+	return true, nil
+}
+
+func InitializeDynamoDBLockTable(client *dynamodb.Client) error {
+	lock := &DynamoDBLock{
+		Client:    client,
+		TableName: tableName,
+		TTL:       ttl,
+	}
+
+	err := lock.createLockTable(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to initialize DynamoDB lock table: %w", err)
+	}
+	return nil
+}
+
+func (lock *DynamoDBLock) createLockTable(ctx context.Context) error {
+	fmt.Printf("Creating DynamoDB lock table: %s\n", lock.TableName)
+	_, err := lock.Client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(lock.TableName),
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("AccountID"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("AccountID"),
+				KeyType:       types.KeyTypeHash,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create lock table: %w", err)
+	}
+
+	fmt.Printf("DynamoDB lock table %s created successfully.\n", lock.TableName)
+	return nil
+}
+
+func (lock *DynamoDBLock) AcquireLock(ctx context.Context, accountID string) error {
+	now := time.Now().Unix()
+	expiration := now + int64(lock.TTL.Seconds())
+
+	_, err := lock.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(lock.TableName),
+		Item: map[string]types.AttributeValue{
+			"AccountID": &types.AttributeValueMemberS{Value: accountID},
+			"Expires":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", expiration)},
+		},
+		ConditionExpression: aws.String("attribute_not_exists(AccountID) OR Expires < :now"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":now": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", now)},
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock for account %s: %w", accountID, err)
+	}
+
+	return nil
+}
+
+func (lock *DynamoDBLock) ReleaseLock(ctx context.Context, accountID string) error {
+	_, err := lock.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(lock.TableName),
+		Key: map[string]types.AttributeValue{
+			"AccountID": &types.AttributeValueMemberS{Value: accountID},
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to release lock for account %s: %w", accountID, err)
+	}
+
+	return nil
+}

--- a/dumie-cli/awsutils/ddb_lock.go
+++ b/dumie-cli/awsutils/ddb_lock.go
@@ -5,7 +5,9 @@ package awsutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,12 +24,20 @@ type DynamoDBLock struct {
 const tableName = "dumie-lock-table"
 const ttl = 5 * time.Minute
 
+func NewDynamoDBLock(client *dynamodb.Client) *DynamoDBLock {
+	return &DynamoDBLock{
+		Client:    client,
+		TableName: tableName,
+		TTL:       ttl,
+	}
+}
+
 func SearchDynamoDBLockTable(client *dynamodb.Client) (bool, error) {
 	_, err := client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
 	if err != nil {
-		if err.Error() == "ResourceNotFoundException" {
+		if errors.As(err, new(*types.ResourceNotFoundException)) {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to describe table: %w", err)
@@ -35,33 +45,19 @@ func SearchDynamoDBLockTable(client *dynamodb.Client) (bool, error) {
 	return true, nil
 }
 
-func InitializeDynamoDBLockTable(client *dynamodb.Client) error {
-	lock := &DynamoDBLock{
-		Client:    client,
-		TableName: tableName,
-		TTL:       ttl,
-	}
-
-	err := lock.createLockTable(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to initialize DynamoDB lock table: %w", err)
-	}
-	return nil
-}
-
-func (lock *DynamoDBLock) createLockTable(ctx context.Context) error {
+func (lock *DynamoDBLock) CreateLockTable(ctx context.Context) error {
 	fmt.Printf("Creating DynamoDB lock table: %s\n", lock.TableName)
 	_, err := lock.Client.CreateTable(ctx, &dynamodb.CreateTableInput{
 		TableName: aws.String(lock.TableName),
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
-				AttributeName: aws.String("AccountID"),
+				AttributeName: aws.String("LockID"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		KeySchema: []types.KeySchemaElement{
 			{
-				AttributeName: aws.String("AccountID"),
+				AttributeName: aws.String("LockID"),
 				KeyType:       types.KeyTypeHash,
 			},
 		},
@@ -76,40 +72,69 @@ func (lock *DynamoDBLock) createLockTable(ctx context.Context) error {
 	return nil
 }
 
-func (lock *DynamoDBLock) AcquireLock(ctx context.Context, accountID string) error {
+func (lock *DynamoDBLock) AcquireLock(ctx context.Context, lockID string) error {
 	now := time.Now().Unix()
 	expiration := now + int64(lock.TTL.Seconds())
 
 	_, err := lock.Client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(lock.TableName),
 		Item: map[string]types.AttributeValue{
-			"AccountID": &types.AttributeValueMemberS{Value: accountID},
-			"Expires":   &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", expiration)},
+			"LockID":  &types.AttributeValueMemberS{Value: lockID},
+			"Expires": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", expiration)},
 		},
-		ConditionExpression: aws.String("attribute_not_exists(AccountID) OR Expires < :now"),
+		ConditionExpression: aws.String("attribute_not_exists(LockID) OR Expires < :now"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":now": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", now)},
 		},
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to acquire lock for account %s: %w", accountID, err)
+		return fmt.Errorf("failed to acquire lock for lockID %s: %w", lockID, err)
 	}
 
 	return nil
 }
 
-func (lock *DynamoDBLock) ReleaseLock(ctx context.Context, accountID string) error {
+func (lock *DynamoDBLock) ReleaseLock(ctx context.Context, lockID string) error {
 	_, err := lock.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
 		TableName: aws.String(lock.TableName),
 		Key: map[string]types.AttributeValue{
-			"AccountID": &types.AttributeValueMemberS{Value: accountID},
+			"LockID": &types.AttributeValueMemberS{Value: lockID},
 		},
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to release lock for account %s: %w", accountID, err)
+		return fmt.Errorf("failed to release lock for lockID %s: %w", lockID, err)
 	}
 
 	return nil
+}
+
+func (lock *DynamoDBLock) CheckLockStatus(ctx context.Context, lockID string) (bool, error) {
+	output, err := lock.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(lock.TableName),
+		Key: map[string]types.AttributeValue{
+			"LockID": &types.AttributeValueMemberS{Value: lockID},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to check lock status for lockID %s: %w", lockID, err)
+	}
+
+	if output.Item == nil {
+		return false, nil
+	}
+
+	now := time.Now().Unix()
+	expires, ok := output.Item["Expires"].(*types.AttributeValueMemberN)
+	if !ok {
+		return false, fmt.Errorf("invalid Expires attribute for lockID %s", lockID)
+	}
+
+	expirationTime, err := strconv.ParseInt(expires.Value, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse Expires attribute for lockID %s: %w", lockID, err)
+	}
+
+	return expirationTime > now, nil
 }

--- a/dumie-cli/cmd/configure.go
+++ b/dumie-cli/cmd/configure.go
@@ -4,6 +4,7 @@ Copyright © 2025 Chanhyeok Seo chanhyeok.seo2@gmail.com
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -99,7 +100,7 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println("Configuration saved successfully.")
+		fmt.Println("Configuration saved successfully. Now initializing DynamoDB lock table...")
 
 		client, err := awsutils.GetDynamoDBClient()
 		if err != nil {
@@ -118,8 +119,11 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		if err := awsutils.InitializeDynamoDBLockTable(client); err != nil {
-			fmt.Printf("Error initializing DynamoDB lock table: %v\n", err)
+		lock := awsutils.NewDynamoDBLock(client)
+
+		err = lock.CreateLockTable(context.Background())
+		if err != nil {
+			fmt.Printf("Error creating DynamoDB lock table: %v\n", err)
 			return
 		}
 

--- a/dumie-cli/cmd/manual.go
+++ b/dumie-cli/cmd/manual.go
@@ -4,6 +4,7 @@ Copyright © 2025 Chanhyeok Seo chanhyeok.seo2@gmail.com
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -16,10 +17,34 @@ var manualCmd = &cobra.Command{
 	Short: "Dumie manual manager",
 	Long:  `TODO`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := awsutils.GetEC2AWSClient()
 
 		profile := args[0]
 
+		lockClient, err := awsutils.GetDynamoDBClient()
+		if err != nil {
+			fmt.Printf("Error getting DynamoDB client: %v\n", err)
+			return
+		}
+
+		lock := awsutils.NewDynamoDBLock(lockClient)
+
+		fmt.Println("Acquiring deployment lock...")
+		err = lock.AcquireLock(context.TODO(), profile)
+		if err != nil {
+			fmt.Printf("Error acquiring deployment lock: %v\n", err)
+			return
+		}
+		fmt.Println("Deployment lock acquired.")
+		defer func() {
+			fmt.Println("Releasing deployment lock...")
+			err := lock.ReleaseLock(context.TODO(), profile)
+			if err != nil {
+				fmt.Printf("Error releasing deployment lock: %v\n", err)
+			}
+			fmt.Println("Deployment lock released.")
+		}()
+
+		client, err := awsutils.GetEC2AWSClient()
 		if err != nil {
 			fmt.Printf("Error getting AWS client: %v\n", err)
 			return

--- a/dumie-cli/cmd/manual.go
+++ b/dumie-cli/cmd/manual.go
@@ -16,7 +16,7 @@ var manualCmd = &cobra.Command{
 	Short: "Dumie manual manager",
 	Long:  `TODO`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := awsutils.GetAWSClient()
+		client, err := awsutils.GetEC2AWSClient()
 
 		profile := args[0]
 

--- a/dumie-cli/go.mod
+++ b/dumie-cli/go.mod
@@ -3,6 +3,7 @@ module github.com/chanhyeokseo/dumie
 go 1.24.1
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.62
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1
@@ -10,12 +11,13 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1 // indirect

--- a/dumie-cli/go.mod
+++ b/dumie-cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.62
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1
 	github.com/spf13/cobra v1.9.1
 )
@@ -15,7 +16,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect

--- a/dumie-cli/go.sum
+++ b/dumie-cli/go.sum
@@ -12,10 +12,14 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0io
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.1 h1:67oYHlAdIoWS65kdTKatf9o1eDNkR2wan6TlBdP3oe4=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1 h1:+4A9SDduLZFlDeXWRmfQ6r8kyEJZQfK6lcg+KwdvWrI=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 h1:M1R1rud7HzDrfCdlBQ7NjnRsDNEhXO/vGhuD189Ggmk=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15/go.mod h1:uvFKBSq9yMPV4LGAi7N4awn4tLY+hKE35f8THes2mzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.1 h1:8JdC7Gr9NROg1Rusk25IcZeTO59zLxsKgE0gkh5O6h0=


### PR DESCRIPTION
Implements #2 

# Summary

This PR implements a DynamoDB-based locking mechanism to prevent concurrent access to the same resource. This prevents race conditions and resource conflicts.

`ddb_lock.go` implements the core locking logic using DynamoDB with TTL-based expiration.

# Key functionalities
- NewDynamoDBLock: Initializes the DDB lock
- SearchDynamoDBLockTable: checks if the table exists
- CreateLockTable: sets up the lock table.
- AcquireLock: creates a lock only if one does not exist or has expired.
- ReleaseLock: releases the lock entry.
- checkLockStatus: returns whether a valid lock currently exists.





