### PR TITLE
Add dumie status command to check profile status

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/dumie-org/dumie-cli/internal/aws/common"
+	"github.com/spf13/cobra"
+)
+
+var showAll bool
+
+func printInstanceTable(instances []types.Instance) {
+	fmt.Printf("\n%-20s %-25s %-15s %-18s %-20s %-10s\n",
+		"NAME", "INSTANCE ID", "STATE", "PUBLIC IP", "LAUNCH TIME", "RESTORED")
+	fmt.Println(strings.Repeat("-", 110))
+
+	for _, instance := range instances {
+
+		name := "-"
+		publicIP := "-"
+		launchTime := "-"
+		var restored string
+
+		for _, tag := range instance.Tags {
+			if *tag.Key == "Name" {
+				name = *tag.Value
+			}
+			if *tag.Key == "Restored" && *tag.Value == "true" {
+				restored = "snapshot"
+			}
+		}
+
+		if instance.PublicIpAddress != nil {
+			publicIP = *instance.PublicIpAddress
+		}
+
+		if instance.LaunchTime != nil {
+			launchTime = instance.LaunchTime.Format("2006-01-02 15:04:05")
+		}
+
+		fmt.Printf("%-20s %-25s %-15s %-18s %-20s %-10s\n",
+			name,
+			*instance.InstanceId,
+			string(instance.State.Name),
+			publicIP,
+			launchTime,
+			restored,
+		)
+	}
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all EC2 instances managed by Dumie",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.TODO()
+
+		// EC2 client 생성
+		client, err := common.GetEC2AWSClient()
+		if err != nil {
+			fmt.Println("Failed to create EC2 client:", err)
+			return
+		}
+
+		input := &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("tag:ManagedBy"),
+					Values: []string{"Dumie"},
+				},
+			},
+		}
+		output, err := client.DescribeInstances(ctx, input)
+		if err != nil {
+			fmt.Println("Failed to describe instances:", err)
+			return
+		}
+
+		var filteredInstances []types.Instance
+		for _, r := range output.Reservations {
+			for _, inst := range r.Instances {
+				if showAll || inst.State.Name == types.InstanceStateNameRunning {
+					filteredInstances = append(filteredInstances, inst)
+				}
+			}
+		}
+
+		if len(filteredInstances) == 0 {
+			fmt.Println("No instances managed by Dumie found.")
+			return
+		}
+
+		printInstanceTable(filteredInstances)
+	},
+}
+
+func init() {
+	listCmd.Flags().BoolVar(&showAll, "all", false, "Show all instances including stopped or terminated ones")
+	rootCmd.AddCommand(listCmd)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -13,62 +15,49 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var showAll bool
+type ProfileInfo struct {
+	Name       string
+	InstanceID string
+	Status     string
+	PublicIP   string
+	LaunchTime string
+}
 
-func printInstanceTable(instances []types.Instance) {
-	fmt.Printf("\n%-20s %-25s %-15s %-18s %-20s %-10s\n",
-		"NAME", "INSTANCE ID", "STATE", "PUBLIC IP", "LAUNCH TIME", "RESTORED")
-	fmt.Println(strings.Repeat("-", 110))
+func printInstanceTable(profiles []ProfileInfo) {
+	fmt.Printf("\n%-20s %-25s %-15s %-18s %-20s\n",
+		"NAME", "INSTANCE ID", "STATUS", "PUBLIC IP", "LAUNCH TIME")
+	fmt.Println(strings.Repeat("-", 105))
 
-	for _, instance := range instances {
-
-		name := "-"
-		publicIP := "-"
-		launchTime := "-"
-		var restored string
-
-		for _, tag := range instance.Tags {
-			if *tag.Key == "Name" {
-				name = *tag.Value
-			}
-			if *tag.Key == "Restored" && *tag.Value == "true" {
-				restored = "snapshot"
-			}
-		}
-
-		if instance.PublicIpAddress != nil {
-			publicIP = *instance.PublicIpAddress
-		}
-
-		if instance.LaunchTime != nil {
-			launchTime = instance.LaunchTime.Format("2006-01-02 15:04:05")
-		}
-
-		fmt.Printf("%-20s %-25s %-15s %-18s %-20s %-10s\n",
-			name,
-			*instance.InstanceId,
-			string(instance.State.Name),
-			publicIP,
-			launchTime,
-			restored,
+	for _, p := range profiles {
+		fmt.Printf("%-20s %-25s %-20s %-18s %-20s\n",
+			p.Name,
+			p.InstanceID,
+			p.Status,
+			p.PublicIP,
+			p.LaunchTime,
 		)
 	}
 }
+
+var showAll bool
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all EC2 instances managed by Dumie",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-		// EC2 client 생성
 		client, err := common.GetEC2AWSClient()
 		if err != nil {
 			fmt.Println("Failed to create EC2 client:", err)
 			return
 		}
 
-		input := &ec2.DescribeInstancesInput{
+		profileMap := map[string]ProfileInfo{}
+
+		// collect instances with ManagedBy=Dumie
+		ec2Input := &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				{
 					Name:   aws.String("tag:ManagedBy"),
@@ -76,31 +65,96 @@ var listCmd = &cobra.Command{
 				},
 			},
 		}
-		output, err := client.DescribeInstances(ctx, input)
+		ec2Output, err := client.DescribeInstances(ctx, ec2Input)
 		if err != nil {
 			fmt.Println("Failed to describe instances:", err)
 			return
 		}
 
-		var filteredInstances []types.Instance
-		for _, r := range output.Reservations {
+		for _, r := range ec2Output.Reservations {
 			for _, inst := range r.Instances {
-				if showAll || inst.State.Name == types.InstanceStateNameRunning {
-					filteredInstances = append(filteredInstances, inst)
+				var name, publicIP, launchTime string
+				name = "-"
+				publicIP = "-"
+
+				for _, tag := range inst.Tags {
+					if *tag.Key == "Name" {
+						name = *tag.Value
+					}
+				}
+
+				if inst.PublicIpAddress != nil {
+					publicIP = *inst.PublicIpAddress
+				}
+				if inst.LaunchTime != nil {
+					launchTime = inst.LaunchTime.Local().Format("2006-01-02 15:04:05")
+				}
+
+				profileMap[name] = ProfileInfo{
+					Name:       name,
+					InstanceID: *inst.InstanceId,
+					Status:     string(inst.State.Name),
+					PublicIP:   publicIP,
+					LaunchTime: launchTime,
 				}
 			}
 		}
 
-		if len(filteredInstances) == 0 {
-			fmt.Println("No instances managed by Dumie found.")
+		// collect snapshots to find archived profiles
+		if showAll {
+			snapInput := &ec2.DescribeSnapshotsInput{
+				Filters: []types.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []string{"Dumie"},
+					},
+				},
+				OwnerIds: []string{"self"},
+			}
+			snapOutput, err := client.DescribeSnapshots(ctx, snapInput)
+			if err == nil {
+				for _, snap := range snapOutput.Snapshots {
+					var profile string
+					for _, tag := range snap.Tags {
+						if *tag.Key == "Name" {
+							profile = *tag.Value
+							break
+						}
+					}
+					if profile != "" {
+						if _, exists := profileMap[profile]; !exists {
+							profileMap[profile] = ProfileInfo{
+								Name:       profile,
+								InstanceID: "-",
+								Status:     "archived",
+								PublicIP:   "-",
+								LaunchTime: "-",
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if len(profileMap) == 0 {
+			fmt.Println("No profiles managed by Dumie found.")
 			return
 		}
 
-		printInstanceTable(filteredInstances)
+		var profiles []ProfileInfo
+		for _, p := range profileMap {
+			if !showAll && !strings.HasPrefix(p.Status, "running") {
+				continue
+			}
+			profiles = append(profiles, p)
+		}
+
+		printInstanceTable(profiles)
 	},
 }
 
 func init() {
-	listCmd.Flags().BoolVar(&showAll, "all", false, "Show all instances including stopped or terminated ones")
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolVar(&showAll, "all", false, "Show all instances and snapshot-only profiles")
+	flag.CommandLine.Parse([]string{}) // for compatibility with cobra+flag
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/dumie-org/dumie-cli/internal/aws/common"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status <profile>",
+	Short: "Show the status of a Dumie-managed instance",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		profile := args[0]
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		client, err := common.GetEC2AWSClient()
+		if err != nil {
+			fmt.Println("Failed to create EC2 client:", err)
+			return
+		}
+
+		// Describe EC2 instance
+		input := &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("tag:Name"),
+					Values: []string{profile},
+				},
+				{
+					Name:   aws.String("tag:ManagedBy"),
+					Values: []string{"Dumie"},
+				},
+			},
+		}
+
+		output, err := client.DescribeInstances(ctx, input)
+		if err != nil {
+			fmt.Printf("Error retrieving instance: %v\n", err)
+			return
+		}
+
+		// Prefer a running instance if multiple instances exist
+		var selected *types.Instance
+		for _, r := range output.Reservations {
+			for _, inst := range r.Instances {
+				if selected == nil || inst.State.Name == types.InstanceStateNameRunning {
+					selected = &inst
+				}
+			}
+		}
+
+		if selected != nil {
+			var source = "base AMI"
+			for _, tag := range selected.Tags {
+				if *tag.Key == "Restored" && *tag.Value == "true" {
+					source = "snapshot"
+					break
+				}
+			}
+
+			publicIP := "-"
+			if selected.PublicIpAddress != nil {
+				publicIP = *selected.PublicIpAddress
+			}
+
+			launchTime := "-"
+			if selected.LaunchTime != nil {
+				launchTime = selected.LaunchTime.Local().Format("2006-01-02 15:04:05")
+			}
+
+			fmt.Println()
+			fmt.Printf("Profile:     %s\n", profile)
+			fmt.Printf("Instance ID: %s\n", *selected.InstanceId)
+			fmt.Printf("State:       %s\n", selected.State.Name)
+			fmt.Printf("Public IP:   %s\n", publicIP)
+			fmt.Printf("Launch Time: %s\n", launchTime)
+			fmt.Printf("Source:      %s\n", source)
+		} else {
+			fmt.Println("No active instance found for this profile.")
+			checkSnapshot(ctx, client, profile)
+		}
+	},
+}
+
+func checkSnapshot(ctx context.Context, client *ec2.Client, profile string) {
+	snapInput := &ec2.DescribeSnapshotsInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:ManagedBy"),
+				Values: []string{"Dumie"},
+			},
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []string{profile},
+			},
+		},
+		OwnerIds: []string{"self"},
+	}
+	output, err := client.DescribeSnapshots(ctx, snapInput)
+	if err != nil {
+		fmt.Println("Error checking snapshots:", err)
+		return
+	}
+
+	if len(output.Snapshots) > 0 {
+		fmt.Printf("\nFound %d snapshot(s) for profile [%s]:\n", len(output.Snapshots), profile)
+		for _, snap := range output.Snapshots {
+			createdAt := "-"
+			if snap.StartTime != nil {
+				createdAt = snap.StartTime.Local().Format("2006-01-02 15:04:05")
+			}
+			fmt.Printf("- Snapshot ID: %s\n", *snap.SnapshotId)
+			fmt.Printf("  Created At:  %s\n", createdAt)
+			fmt.Printf("  Size (GiB):  %d\n", snap.VolumeSize)
+		}
+	} else {
+		fmt.Printf("No instance or snapshot found for profile [%s].\n", profile)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}

--- a/internal/aws/ec2/deployment.go
+++ b/internal/aws/ec2/deployment.go
@@ -73,7 +73,7 @@ func launchNewInstance(ctx context.Context, client *ec2.Client, profile string, 
 		return "", fmt.Errorf("failed to get key pair: %w", err)
 	}
 
-	instanceIDPtr, err := LaunchEC2Instance(client, profile, amiID, types.InstanceTypeT2Micro, sgID, keyName, userDataPath, iamRoleARN)
+	instanceIDPtr, err := LaunchEC2Instance(client, profile, amiID, types.InstanceTypeT2Micro, sgID, keyName, userDataPath, iamRoleARN, false)
 	if err != nil {
 		return "", fmt.Errorf("failed to launch instance: %w", err)
 	}

--- a/internal/aws/ec2/ec2_utils.go
+++ b/internal/aws/ec2/ec2_utils.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,7 +110,7 @@ func SearchEC2Instance(client *ec2.Client, profile string) (*string, error) {
 	return describeInstancesOutput.Reservations[0].Instances[0].InstanceId, nil
 }
 
-func LaunchEC2Instance(client *ec2.Client, profile string, amiID string, instanceType types.InstanceType, sgID *string, keyName string, userDataPath *string, iamRoleARN *string) (*string, error) {
+func LaunchEC2Instance(client *ec2.Client, profile string, amiID string, instanceType types.InstanceType, sgID *string, keyName string, userDataPath *string, iamRoleARN *string, restored bool) (*string, error) {
 	var userData *string
 	if userDataPath != nil {
 		// Load and encode user_data script
@@ -132,6 +133,10 @@ func LaunchEC2Instance(client *ec2.Client, profile string, amiID string, instanc
 				{
 					Key:   aws.String("ManagedBy"),
 					Value: aws.String("Dumie"),
+				},
+				{
+					Key:   aws.String("Restored"),
+					Value: aws.String(strconv.FormatBool(restored)),
 				},
 			},
 		},

--- a/internal/aws/ec2/ec2_utils.go
+++ b/internal/aws/ec2/ec2_utils.go
@@ -115,6 +115,10 @@ func LaunchEC2Instance(client *ec2.Client, profile string, amiID string, instanc
 					Key:   aws.String("Name"),
 					Value: aws.String(profile),
 				},
+				{
+					Key:   aws.String("ManagedBy"),
+					Value: aws.String("Dumie"),
+				},
 			},
 		},
 	}

--- a/internal/aws/ec2/snapshot.go
+++ b/internal/aws/ec2/snapshot.go
@@ -100,7 +100,7 @@ func TryRestoreFromSnapshot(ctx context.Context, client *ec2.Client, profile str
 	}
 
 	// Launch EC2 Instance
-	instanceIDPtr, err := LaunchEC2Instance(client, profile, amiID, types.InstanceTypeT2Micro, sgID, keyName, nil, iamRoleARN)
+	instanceIDPtr, err := LaunchEC2Instance(client, profile, amiID, types.InstanceTypeT2Micro, sgID, keyName, nil, iamRoleARN, true)
 	if err != nil {
 		return "", fmt.Errorf("failed to launch instance: %w", err)
 	}


### PR DESCRIPTION
## Add `dumie status` command to inspect profile status

- Closes #17 

### Features

- Adds a new `dumie status <profile>` command to show the detailed status of a Dumie-managed profile.
- When an active EC2 instance exists for the profile, it shows:
  - Instance ID  
  - State (`running`, `stopped`, `terminated`, etc.)
  - Public IP address  
  - Launch time  
  - Source (`base AMI` or `snapshot`)
- If no instance is found but a snapshot exists:
  - Displays snapshot details (snapshot ID, creation time, and volume size).
- Prefers a `running` instance when multiple (e.g. `running` + `terminated`) exist for the same profile.

